### PR TITLE
Add support for dashed message lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ alias ali = "Alice"
 
 ali->Bob: "Hello!"
 Bob->Bob: "(Bob thinks)"
-Bob->ali: "Hello back!"
+Bob-->ali: "Hello back!"
 EOF
 
 $ diagwiz < example.diag
@@ -56,7 +56,7 @@ $ diagwiz < example.diag
     │               │◀┘
     │               │
     │  Hello back!  │
-    │◀──────────────│
+    │◀--------------│
     │               │
 ┌───────┐        ┌─────┐
 │ Alice │        │ Bob │

--- a/site/src/routes/playground/index.svelte
+++ b/site/src/routes/playground/index.svelte
@@ -20,7 +20,7 @@ alias ali = "Alice"
 
 ali->Bob: "Hello!"
 Bob->Bob: "(Bob thinks)"
-Bob->ali: "Hello back!"
+Bob-->ali: "Hello back!"
 `.trim();
   let initialContent: string;
 

--- a/src/diagrams/seq/src/layout.rs
+++ b/src/diagrams/seq/src/layout.rs
@@ -149,10 +149,17 @@ impl Render<BareRenderCtx> for Arc<Participant> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum EdgeStyle {
+    Single,
+    Double,
+}
+
 pub struct Message {
     pub source: Arc<Participant>,
     pub target: Arc<Participant>,
     pub payload: String,
+    pub edge_style: EdgeStyle,
 }
 
 struct MessageRenderCtx {
@@ -208,15 +215,19 @@ impl Render<MessageRenderCtx> for Message {
             }
             false => {
                 let left_padding = ((width - len) / 2) as usize;
+                let arrow_char = match self.edge_style {
+                    EdgeStyle::Single => '─',
+                    EdgeStyle::Double => '-',
+                };
 
-                let mut arrow = "─".repeat(width - 2);
+                let mut arrow = arrow_char.to_string().repeat(width - 2);
                 match ctx.source_idx > ctx.target_idx {
                     true => {
-                        arrow.push('─');
+                        arrow.push(arrow_char);
                         arrow.insert(0, '◀');
                     }
                     false => {
-                        arrow.insert(0, '─');
+                        arrow.insert(0, arrow_char);
                         arrow.push('▶');
                     }
                 }
@@ -459,16 +470,19 @@ mod test {
             source: participant_alice.clone(),
             target: participant_bob.clone(),
             payload: "hello".to_string(),
+            edge_style: EdgeStyle::Single,
         });
         layout.add_message(Message {
             source: participant_bob.clone(),
             target: participant_alice.clone(),
             payload: "hello back".to_string(),
+            edge_style: EdgeStyle::Single,
         });
         layout.add_message(Message {
             source: participant_bob.clone(),
             target: participant_bob.clone(),
             payload: "who am i?".to_string(),
+            edge_style: EdgeStyle::Double,
         });
         let output = layout.render();
         assert!(output.len() > 0);

--- a/src/diagrams/seq/src/layout.rs
+++ b/src/diagrams/seq/src/layout.rs
@@ -151,8 +151,8 @@ impl Render<BareRenderCtx> for Arc<Participant> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum EdgeStyle {
-    Single,
-    Double,
+    Continuous,
+    Dashed,
 }
 
 pub struct Message {
@@ -216,8 +216,8 @@ impl Render<MessageRenderCtx> for Message {
             false => {
                 let left_padding = ((width - len) / 2) as usize;
                 let arrow_char = match self.edge_style {
-                    EdgeStyle::Single => '─',
-                    EdgeStyle::Double => '-',
+                    EdgeStyle::Continuous => '─',
+                    EdgeStyle::Dashed => '-',
                 };
 
                 let mut arrow = arrow_char.to_string().repeat(width - 2);
@@ -470,19 +470,19 @@ mod test {
             source: participant_alice.clone(),
             target: participant_bob.clone(),
             payload: "hello".to_string(),
-            edge_style: EdgeStyle::Single,
+            edge_style: EdgeStyle::Continuous,
         });
         layout.add_message(Message {
             source: participant_bob.clone(),
             target: participant_alice.clone(),
             payload: "hello back".to_string(),
-            edge_style: EdgeStyle::Single,
+            edge_style: EdgeStyle::Continuous,
         });
         layout.add_message(Message {
             source: participant_bob.clone(),
             target: participant_bob.clone(),
             payload: "who am i?".to_string(),
-            edge_style: EdgeStyle::Double,
+            edge_style: EdgeStyle::Dashed,
         });
         let output = layout.render();
         assert!(output.len() > 0);

--- a/src/diagrams/seq/src/parser.rs
+++ b/src/diagrams/seq/src/parser.rs
@@ -6,8 +6,8 @@ pub struct SequenceDiagramParser;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum EdgeStyle {
-    Single,
-    Double,
+    Continuous,
+    Dashed,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -18,10 +18,10 @@ enum EdgeDirection {
 
 fn parse_edge(edge: &str) -> Result<(EdgeStyle, EdgeDirection), ParserError> {
     match edge {
-        "->" => Ok((EdgeStyle::Single, EdgeDirection::Right)),
-        "-->" => Ok((EdgeStyle::Double, EdgeDirection::Right)),
-        "<-" => Ok((EdgeStyle::Single, EdgeDirection::Left)),
-        "<--" => Ok((EdgeStyle::Double, EdgeDirection::Left)),
+        "->" => Ok((EdgeStyle::Continuous, EdgeDirection::Right)),
+        "-->" => Ok((EdgeStyle::Dashed, EdgeDirection::Right)),
+        "<-" => Ok((EdgeStyle::Continuous, EdgeDirection::Left)),
+        "<--" => Ok((EdgeStyle::Dashed, EdgeDirection::Left)),
         _ => Err(ParserError::SyntaxError("Invalid edge".to_string())),
     }
 }
@@ -180,10 +180,10 @@ mod test {
     fn parse_message_distinguishes_edge_style() {
         let data = r#"a->b"#;
         let result = diagram(String::from(data)).unwrap();
-        assert_eq!(result.messages[0].edge_style, EdgeStyle::Single);
+        assert_eq!(result.messages[0].edge_style, EdgeStyle::Continuous);
         let data = r#"a-->b"#;
         let result = diagram(String::from(data)).unwrap();
-        assert_eq!(result.messages[0].edge_style, EdgeStyle::Double);
+        assert_eq!(result.messages[0].edge_style, EdgeStyle::Dashed);
     }
 
     #[test]

--- a/src/diagrams/seq/src/parser.rs
+++ b/src/diagrams/seq/src/parser.rs
@@ -5,6 +5,28 @@ use pest::Parser;
 pub struct SequenceDiagramParser;
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum EdgeStyle {
+    Single,
+    Double,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum EdgeDirection {
+    Left,
+    Right,
+}
+
+fn parse_edge(edge: &str) -> Result<(EdgeStyle, EdgeDirection), ParserError> {
+    match edge {
+        "->" => Ok((EdgeStyle::Single, EdgeDirection::Right)),
+        "-->" => Ok((EdgeStyle::Double, EdgeDirection::Right)),
+        "<-" => Ok((EdgeStyle::Single, EdgeDirection::Left)),
+        "<--" => Ok((EdgeStyle::Double, EdgeDirection::Left)),
+        _ => Err(ParserError::SyntaxError("Invalid edge".to_string())),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Alias {
     /// The ID of the node
     pub id: String,
@@ -16,6 +38,8 @@ pub struct Alias {
 pub struct Message {
     /// The sender of the message
     pub source: String,
+    /// The style of the message arrow
+    pub edge_style: EdgeStyle,
     /// The recipient of the message
     pub target: String,
     /// The edge label
@@ -56,11 +80,19 @@ pub fn diagram(input: String) -> Result<SequenceDiagram, ParserError> {
                         });
                     }
                     Rule::pair => {
-                        // { name ~ "->" ~ name ~ ":" ~ string }
+                        // { name ~ edge ~ name ~ ":" ~ string }
                         let mut inner_rules = stmt.into_inner();
 
                         let source: &str = inner_rules.next().unwrap().as_str();
+                        let edge: &str = inner_rules.next().unwrap().as_str();
+
+                        // Swap source and target if needed
+                        let (edge_style, edge_direction) = parse_edge(edge)?;
                         let target: &str = inner_rules.next().unwrap().as_str();
+                        let (source, target) = match edge_direction {
+                            EdgeDirection::Right => (source, target),
+                            EdgeDirection::Left => (target, source),
+                        };
                         let label: &str = match inner_rules.peek() {
                             Some(_) => inner_rules.next().unwrap().as_str(),
                             None => "",
@@ -70,6 +102,7 @@ pub fn diagram(input: String) -> Result<SequenceDiagram, ParserError> {
                             source: String::from(source),
                             target: String::from(target),
                             payload: String::from(label),
+                            edge_style,
                         });
                     }
                     Rule::EOI => (),
@@ -114,6 +147,18 @@ mod test {
     }
 
     #[test]
+    fn parse_handles_directions() {
+        let data = "a->b";
+        let result = diagram(String::from(data)).unwrap();
+        assert_eq!(result.messages[0].source, "a");
+        assert_eq!(result.messages[0].target, "b");
+        let data = "a<-b";
+        let result = diagram(String::from(data)).unwrap();
+        assert_eq!(result.messages[0].source, "b");
+        assert_eq!(result.messages[0].target, "a");
+    }
+
+    #[test]
     fn parse_message_payload_with_unicode() {
         let data = r#"a->b: "𩸽""#;
         let result = diagram(String::from(data)).unwrap();
@@ -129,6 +174,16 @@ mod test {
         let result = diagram(String::from(data)).unwrap();
         assert_eq!(result.messages.len(), 1);
         assert_eq!(result.messages[0].payload, "\"hello\"");
+    }
+
+    #[test]
+    fn parse_message_distinguishes_edge_style() {
+        let data = r#"a->b"#;
+        let result = diagram(String::from(data)).unwrap();
+        assert_eq!(result.messages[0].edge_style, EdgeStyle::Single);
+        let data = r#"a-->b"#;
+        let result = diagram(String::from(data)).unwrap();
+        assert_eq!(result.messages[0].edge_style, EdgeStyle::Double);
     }
 
     #[test]

--- a/src/diagrams/seq/src/renderer.rs
+++ b/src/diagrams/seq/src/renderer.rs
@@ -70,8 +70,8 @@ pub fn render(diag: parser::SequenceDiagram) -> String {
             target: participants.get(&message.target).unwrap().clone(),
             payload: message.payload,
             edge_style: match message.edge_style {
-                parser::EdgeStyle::Single => layout::EdgeStyle::Single,
-                parser::EdgeStyle::Double => layout::EdgeStyle::Double,
+                parser::EdgeStyle::Continuous => layout::EdgeStyle::Continuous,
+                parser::EdgeStyle::Dashed => layout::EdgeStyle::Dashed,
             },
         })
     }

--- a/src/diagrams/seq/src/renderer.rs
+++ b/src/diagrams/seq/src/renderer.rs
@@ -69,6 +69,10 @@ pub fn render(diag: parser::SequenceDiagram) -> String {
             source: participants.get(&message.source).unwrap().clone(),
             target: participants.get(&message.target).unwrap().clone(),
             payload: message.payload,
+            edge_style: match message.edge_style {
+                parser::EdgeStyle::Single => layout::EdgeStyle::Single,
+                parser::EdgeStyle::Double => layout::EdgeStyle::Double,
+            },
         })
     }
 

--- a/src/diagrams/seq/src/syntax.pest
+++ b/src/diagrams/seq/src/syntax.pest
@@ -23,8 +23,9 @@ string_char = {
     | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
 
+edge = { "-->" | "->" | "<--" | "<-" }
 alias = { ^"alias " ~ identifier ~ "=" ~ string }
-pair = { identifier ~ "->" ~ identifier ~ (":" ~ string)? }
+pair = { identifier ~ edge ~ identifier ~ (":" ~ string)? }
 
 expr = _{ alias | pair }
 main = { SOI ~ ((expr? ~ NEWLINE)* ~ EOI) | (expr? ~ EOI) }


### PR DESCRIPTION
Also adds support for omnidirectional message arrows. Demo of both features below.

#### Input

```
ali->bob: "Hello!"
ali<--bob: "Hello back!"
```

#### Output

```
┌──────┐         ┌──────┐ 
│ ali  │         │ bob  │ 
└──────┘         └──────┘ 
    │     Hello!     │    
    │───────────────▶│    
    │                │    
    │  Hello back!   │    
    │◀---------------│    
    │                │    
┌──────┐         ┌──────┐ 
│ ali  │         │ bob  │ 
└──────┘         └──────┘ 
```
